### PR TITLE
add adapter template and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a DAML integration implementing the [Exberry APIs](https://docs.exberry.
 
 ## To configure
 
-The integration requires a set of credentials and URLs for connecting and authenticating to Exberry. 
+The integration requires a set of credentials and URLs for connecting and authenticating to Exberry.
 
 
 - Username: your user name for the Management API
@@ -17,3 +17,10 @@ The integration requires a set of credentials and URLs for connecting and authen
 - Secret: The API secret for authenticating to Exberry’s matching engine
 
 > This integration is under active development. Please raise any Github issues or direct your questions to the [DAML forum](https://discuss.daml.com/)
+
+
+## Adapter
+
+When running the Exberry Integration on DamlHub, you may want to use a python adapter bot to listen
+for and create integration contracts based on the needs of your app. A starter template can be found in
+the `adapter_template` folder, and a more concrete example can be found in the [Daml Marketplace](https://github.com/digital-asset/da-marketplace/tree/v0.1.17/exberry_adapter).

--- a/adapter_template/.gitignore
+++ b/adapter_template/.gitignore
@@ -1,0 +1,3 @@
+bot.egg-info/
+build/
+dist/

--- a/adapter_template/Pipfile
+++ b/adapter_template/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+dazl = "*"
+aiohttp = "*"
+
+[requires]
+python_version = "3.7"

--- a/adapter_template/bot/__init__.py
+++ b/adapter_template/bot/__init__.py
@@ -1,0 +1,3 @@
+from .exberry_adapter_bot import main
+
+main()

--- a/adapter_template/bot/exberry_adapter_bot.py
+++ b/adapter_template/bot/exberry_adapter_bot.py
@@ -1,0 +1,65 @@
+import logging
+import os
+from datetime import datetime
+
+import dazl
+from dazl import create, exercise, exercise_by_key
+
+dazl.setup_default_logger(logging.INFO)
+
+class EXBERRY:
+    NewOrderRequest = 'Exberry.Integration:NewOrderRequest'
+    NewOrderSuccess = 'Exberry.Integration:NewOrderSuccess'
+    NewOrderFailure = 'Exberry.Integration:NewOrderFailure'
+    CancelOrderRequest = 'Exberry.Integration:CancelOrderRequest'
+    CancelOrderSuccess = 'Exberry.Integration:CancelOrderSuccess'
+    CancelOrderFailure = 'Exberry.Integration:CancelOrderFailure'
+    CreateInstrumentRequest = 'Exberry.Integration:CreateInstrumentRequest'
+    Instrument = 'Exberry.Integration:Instrument'
+    FailedInstrumentRequest = 'Exberry.Integration:FailedInstrumentRequest'
+    ExecutionReport = 'Exberry.Integration:ExecutionReport'
+    MassCancelRequest = 'Exberry.Integration:MassCancelRequest'
+
+def main():
+    url = os.getenv('DAML_LEDGER_URL')
+    exchange = os.getenv('DAML_LEDGER_PARTY')
+
+    exchange_party = "Exchange" if not exchange else exchange
+
+    network = dazl.Network()
+    network.set_config(url=url)
+
+    logging.info(f'Integration will run under party: {exchange_party}')
+
+    client = network.aio_party(exchange_party)
+
+    @client.ledger_ready()
+    def say_hello(event):
+        logging.info("DA Marketplace <> Exberry adapter is ready!")
+
+    @client.ledger_created(EXBERRY.NewOrderSuccess)
+    async def handle_new_order_success(event):
+        logging.info(f"Handling NewOrderSuccess")
+
+    @client.ledger_created(EXBERRY.NewOrderFailure)
+    async def handle_new_order_failure(event):
+        logging.info(f"Handling NewOrderFailure")
+
+    @client.ledger_created(EXBERRY.CancelOrderSuccess)
+    async def handle_cancel_order_success(event):
+        logging.info(f"Handling CancelOrderSuccess")
+
+    @client.ledger_created(EXBERRY.CancelOrderFailure)
+    async def handle_cancel_order_failure(event):
+        logging.info(f"Handling CancelOrderFailure")
+
+    @client.ledger_created(EXBERRY.ExecutionReport)
+    async def handle_execution_report(event):
+        logging.info(f"Handling execution report")
+
+    network.run_forever()
+
+if __name__ == "__main__":
+    logging.info("DA Marketplace <> Exberry adapter is starting up...")
+
+    main()

--- a/adapter_template/setup.py
+++ b/adapter_template/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='exberry-adapter',
+      version='0.1.16',
+      description='Exchange Adapter Starter Tempalte',
+      author='Digital Asset',
+      url='daml.com',
+      license='Apache2',
+      install_requires=['dazl>=7,<8', 'aiohttp'],
+      packages=['bot'],
+      include_package_data=True)

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -11,6 +11,7 @@ catalog:
     license: Apache-2.0
     tags: [ integration ]
     icon_file: exberry-icon.png
+    source_url: https://github.com/digital-asset/daml-dit-integration-exberry
 integration_types:
     - id: com.projectdabl.integrations.exberry.integration
       name: Exberry


### PR DESCRIPTION
Adds a template for building a dazl bot adapter for use with the integration - this may help a user new to the integration get it up and running quicker with their app.