### PR TITLE
change to resusbscribe for all orderbook errors

### DIFF
--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -4,7 +4,7 @@
 catalog:
     name: dabl-integration-exberry
     group_id: com.digitalasset
-    version: 0.7.5
+    version: 0.7.6
     short_description: Exberry
     description: Exberry Trading and Management API Integration
     author: Digital Asset (Switzerland) GmbH

--- a/src/exberry_int/integration_exberry.py
+++ b/src/exberry_int/integration_exberry.py
@@ -202,7 +202,9 @@ def integration_exberry_main(
                 error_code = msg['d']['errorCode']
                 error_message = msg['d']['errorMessage']
                 LOG.error(f'Orderbook Error - Type: {error_type}, Code: {error_code}, Message: {error_message}')
-                if error_code == 1200:
+
+                # error code 400 indicates there is already an existing subscription, otherwise resubscibe
+                if error_code != 400:
                     LOG.warning('Possibly lost order book subscription, resubscribing...')
                     await outbound_queue.put(make_order_book_depth())
             else:


### PR DESCRIPTION
Changes the order book error logic to resubscribe on all errors (except an already existing subscription error, which indicates a previous resubscribe was not necessary), as per discussion with Exberry.